### PR TITLE
Version 2: Add normalize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ A javascript library for generating Ethereum Name Service (ENS) namehashes per [
 
 ```javascript
 var namehash = require('eth-ens-namehash')
-var hash = namehash('foo.eth')
+var hash = namehash.hash('foo.eth')
 // '0xde9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f'
+
+// Also supports normalizing strings to ENS compatibility:
+var input = getUserInput()
+var normalized = namehash.normalize(input)
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var sha3 = require('js-sha3').keccak_256
 var uts46 = require('idna-uts46')
 
-module.exports = function namehash (inputName) {
+function namehash (inputName) {
   // Reject empty names:
   var node = ''
   for (var i = 0; i < 32; i++) {
@@ -25,3 +25,6 @@ module.exports = function namehash (inputName) {
 function normalize(name) {
   return name ? uts46.toUnicode(name, {useStd3ASCII: true, transitional: false}) : name
 }
+
+exports.hash = namehash
+exports.normalize = normalize

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-ens-namehash",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A simple module for generating ENS namehashes per spec https://github.com/ethereum/EIPs/issues/137",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -8,14 +8,14 @@ test('empty name', (t) => {
   t.plan(1)
   const input = ''
   const expected = '0x0000000000000000000000000000000000000000000000000000000000000000'
-  const output = namehash(input)
+  const output = namehash.hash(input)
   t.equal(output, expected)
 })
 
 test('empty param', (t) => {
   t.plan(1)
   const expected = '0x0000000000000000000000000000000000000000000000000000000000000000'
-  const output = namehash()
+  const output = namehash.hash()
   t.equal(output, expected)
 })
 
@@ -23,7 +23,7 @@ test('TLD eth', (t) => {
   t.plan(1)
   const input = 'eth'
   const expected = '0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae'
-  const output = namehash(input)
+  const output = namehash.hash(input)
   t.equal(output, expected)
 })
 
@@ -31,7 +31,14 @@ test('foo.eth', (t) => {
   t.plan(1)
   const input = 'foo.eth'
   const expected = '0xde9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f'
-  const output = namehash(input)
+  const output = namehash.hash(input)
   t.equal(output, expected)
 })
 
+test('normalize', (t) => {
+  t.plan(1)
+  const input = 'foo.eth'
+  const expected = 'foo.eth'
+  const output = namehash.normalize(input)
+  t.equal(output, expected)
+})


### PR DESCRIPTION
Is a major breaking change, because we now export an object instead of a lone function.

Fixes #1